### PR TITLE
Fix login redirect flow

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import { useAuthStore } from './store/authStore';
 import Navbar from './components/Layout/Navbar';
 import Login from './pages/Login';
 import Register from './pages/Register';
+import Home from './pages/Home';
 import Dashboard from './pages/Dashboard';
 import Requests from './pages/Requests';
 import RequestDetail from './pages/RequestDetail';
@@ -29,6 +30,7 @@ function App() {
   if (!user) {
     return (
       <Routes>
+        <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
         <Route path="*" element={<Navigate to="/login" replace />} />

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Container, Box, Typography, Button } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+const Home = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Container component="main" maxWidth="sm" sx={{ mt: 8 }}>
+      <Box textAlign="center">
+        <Typography variant="h3" component="h1" gutterBottom>
+          Welcome to Resource Manager
+        </Typography>
+        <Typography variant="subtitle1" sx={{ mb: 4 }}>
+          Please sign in to manage resources or register for an account.
+        </Typography>
+        <Box sx={{ display: 'flex', justifyContent: 'center', gap: 2 }}>
+          <Button variant="contained" onClick={() => navigate('/login')}>
+            Login
+          </Button>
+          <Button variant="outlined" onClick={() => navigate('/register')}>
+            Register
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+export default Home;
+


### PR DESCRIPTION
## Summary
- add a new Home page
- show Home page if not logged in
- adjust unauthenticated routing logic so protected routes redirect to login

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` in `frontend` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864f89aa97c83268f82f11c5560615f