### PR TITLE
Fix login refresh loop

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -25,8 +25,11 @@ api.interceptors.response.use(
   },
   (error) => {
     if (error.response?.status === 401) {
-      // Handle unauthorized access
-      window.location.href = '/login';
+      // Prevent redirect loop if already on auth pages
+      const authPaths = ['/login', '/register'];
+      if (typeof window !== 'undefined' && !authPaths.includes(window.location.pathname)) {
+        window.location.href = '/login';
+      }
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
## Summary
- ensure API auth failure doesn't redirect to login repeatedly

## Testing
- `npm test --silent` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864fcd79df8832681d9cfa4278b4d02