### PR TITLE
Fix login page refresh loop

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -25,8 +25,11 @@ api.interceptors.response.use(
   },
   (error) => {
     if (error.response?.status === 401) {
-      // Handle unauthorized access
-      window.location.href = '/login';
+      const currentPath = window.location.pathname;
+      // Avoid infinite redirect loop when already on auth pages
+      if (currentPath !== '/login' && currentPath !== '/register') {
+        window.location.href = '/login';
+      }
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
## Summary
- avoid redirecting to `/login` from the Axios 401 interceptor when already on an auth page

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6864fcd79df8832681d9cfa4278b4d02